### PR TITLE
Fixed call to function mk_padding in print_prop

### DIFF
--- a/tools/mapgen/tmx.c
+++ b/tools/mapgen/tmx.c
@@ -85,7 +85,7 @@ void mk_padding(char pad[11], int depth) {
 }
 
 void print_prop(tmx_property *p, void *depth) {
-	char padding[12]; mk_padding(padding, (int)depth);
+	char padding[11]; mk_padding(padding, *((int*)depth));
 
 	printf("\n%s" "'%s'=(", padding, p->name);
 	switch(p->type) {


### PR DESCRIPTION
In print top there is a call to void mk_padding(char pad[11], int depth).
mkpadding expects a 11 byte array as first argument but the variable 'padding' is 12 bytes long, I stripped the extra byte.
In addition, the second parameter is of type int but depth is a pointer to void, so I casted the pointer to int* and then passed the value to the function.
I don't know what print_prop and mk_padding are meant to but without this commit the project can't correctly compile.
